### PR TITLE
Fixed issue: compile_commands.json was not being used with Lint on-the-fly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -146,7 +146,7 @@ module.exports = {
       }
     }
     module.exports.last_linted_files.add(real_file)
-    command = require("./utility").buildCommand(editor, linted_file);
+    command = require("./utility").buildCommand(editor, linted_file, real_file);
     return require("sb-exec").exec(command.binary, command.args, {stream: "stderr"}).then(output => {
       msgs = require("./utility.js").parse(output,editor)
       msgs.forEach(function(entry){

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -122,7 +122,7 @@ module.exports = {
     });
     return output;
   },
-  buildCommand: function(activeEditor, file) {
+  buildCommand: function(activeEditor, file, real_file) {
     config = require("./config");
     var path = require('path');
     var fs = require('fs')
@@ -150,12 +150,19 @@ module.exports = {
         try {
           compile_commands = require(commands_file)
           compile_commands.forEach(function(item) {
-            if (item.file == file) {
+            if (item.file == real_file) {
               command_array = module.exports.splitStringTrim(item.command, " ", false, "")
               command = command_array[0]
               command_array.shift()
               command_array = module.exports.removeOutputArgument(command_array)
               args = args.concat(command_array)
+              if (atom.config.get("linter-gcc2.gccLintOnTheFly") == true) {
+                for (i = 0; i < args.length; i++) {
+                  if (args[i] == real_file) {
+                    args[i] = file;
+                  }
+                }
+              }
             }
           })
         } catch (e) {


### PR DESCRIPTION
When lint on-the-fly is enabled the compile_commands.json file would be ignored due to lint on-the-fly using a temporary file. This commit fixes the issue by always checking the compile_commands against the permanent file instead of the temporary one. In addition it will also update the command from compile_commands.json to use the temporary file