### PR TITLE
Fixed issue where modifications to compile_commands.json would be ignored by linter-gcc2

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -147,9 +147,8 @@ module.exports = {
       }
       if (fs.existsSync(commands_file)) {
 
-        delete require.cache[commands_file]
         try {
-          compile_commands = require(commands_file)
+          compile_commands = JSON.parse(fs.readFileSync(commands_file));
           compile_commands.forEach(function(item) {
             if (item.file == real_file) {
               command_array = module.exports.splitStringTrim(item.command, " ", false, "")


### PR DESCRIPTION
When a change is made to compile_commands.json the change was ignored by linter_gcc2 due to the method being used for reading the file. This fix uses a different method to read the file and therefor does not have this issue